### PR TITLE
Fix crash when `config.converters` is nil in setup()

### DIFF
--- a/lua/hexer/init.lua
+++ b/lua/hexer/init.lua
@@ -24,7 +24,7 @@ function M.setup(config)
         for _, v in ipairs(M._config.converters) do
             table.insert(all_converters, v)
         end
-        for _, v in ipairs(config.converters) do
+        for _, v in ipairs(config.converters or {}) do
             table.insert(all_converters, v)
         end
 


### PR DESCRIPTION
setup() crashes when a user provides a partial configuration table that does not include the converters field.
This results in:
```
.local/share/nvim/lazy/hexer.nvim/lua/hexer/init.lua:27: bad argument #1 to 'ipairs' (table expected, got nil) 
# stacktrace: 
- /hexer.nvim/lua/hexer/init.lua:27 _in_ **setup** 
- hexer.lua:3 
- ~/.config/nvim/lua/plugins/hexer.lua:7 _in_ **config** 
- ~/.config/nvim/init.lua:28
```

In setup():
```
for _, v in ipairs(config.converters) do
```
When config is provided but config.converters is not defined,
ipairs(nil) is invoked, causing a runtime error.

Fixed it with a guard againt nil by defaulting to an empty table:
```
for _, v in ipairs(config.converters or {}) do
```
